### PR TITLE
Update CI/CD for black and isort compatibility

### DIFF
--- a/195B_README.md
+++ b/195B_README.md
@@ -63,6 +63,7 @@ NeuroSync addresses the problem by utilizing electroencephalogram (EEG) technolo
 | Language | Python 3.13.* |
 | Package Management | uv |
 | Signal Processing | SciPy, NumPy |
+| Data Formatting and Analysis | pandas |
 | Data I/O | pyserial, muselsl/pylsl |
 | Testing | PyTest |
 

--- a/195B_README.md
+++ b/195B_README.md
@@ -54,6 +54,7 @@ NeuroSync addresses the problem by utilizing electroencephalogram (EEG) technolo
 | Category | Technology |
 |----------|------------|
 | Language | SystemVerilog |
+| Communication Protocol | UART |
 | FPGA Board | Diligent Nexys A7-100T |
 | EEG headband | Muse 2 |
 

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -49,5 +49,5 @@ profile = "black"
 line-length = 79
 
 [tool.black]
-line-length = 79
-target-version = ["py313"]
+line_length = 79
+py_version = 313

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -46,6 +46,7 @@ url = "https://pypi.org/simple"
 
 [tool.isort]
 profile = "black"
+line-length = 79
 
 [tool.black]
 line-length = 79

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -46,8 +46,8 @@ url = "https://pypi.org/simple"
 
 [tool.isort]
 profile = "black"
-line-length = 79
+line_length = 79
 
 [tool.black]
-line_length = 79
-py_version = 313
+line-length = 79
+target-version = ["py313"]

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -44,6 +44,9 @@ default = true
 name = "pypi"
 url = "https://pypi.org/simple"
 
+[tool.isort]
+profile = "black"
+
 [tool.black]
 line-length = 79
 target-version = ["py313"]

--- a/software/src/data_processing.py
+++ b/software/src/data_processing.py
@@ -44,8 +44,7 @@ def get_data(file_name):
     if not isinstance(file_name, str):
         raise TypeError("file_name must be a string")
 
-    folder_name = "data"
-    path = os.path.join(folder_name, file_name)
+    path = os.path.join(FOLDER_NAME, file_name)
     return path
 
 

--- a/software/tests/test_transmission.py
+++ b/software/tests/test_transmission.py
@@ -4,9 +4,16 @@ from unittest.mock import MagicMock, call
 import crcmod
 import pandas as pd
 
-from transmission import (PAYLOAD_LENGTH, SYNC_BYTE_1, SYNC_BYTE_2,
-                          df_to_packet, packet_to_df, receive, transmit,
-                          validate_packet)
+from transmission import (
+    PAYLOAD_LENGTH,
+    SYNC_BYTE_1,
+    SYNC_BYTE_2,
+    df_to_packet,
+    packet_to_df,
+    receive,
+    transmit,
+    validate_packet,
+)
 
 # helper function with creation of mock packet
 crc8 = crcmod.predefined.mkCrcFun("crc-8")


### PR DESCRIPTION
# Pull Request

## Description

The black and isort formatters sometimes conflict in their changes. This PR addresses that by having isort comply with black formatting. By adding this to the pyproject.toml, both will work together during CI/CD checks instead of causing errors due to conflicts.

## Type of Change

-   [ ] Bug fix
-   [ ] New feature
-   [x] Refactor
-   [ ] Documentation

## Related Issue

Resolves #26 