### PR TITLE
Fix: broken resolve streams in main

### DIFF
--- a/195B_README.md
+++ b/195B_README.md
@@ -95,6 +95,9 @@ source .venv/bin/activate        # macOS / Linux
 
 # Install dependencies
 cd software/
+chmod +x scripts/*
+# Before the next step, make sure neurosync/software/scripts is added to PATH
+./install-liblsl
 uv sync
 ```
 

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -34,6 +34,9 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.pytest.ini_options]
+pythonpath = ["tests"]
+
 [tool.uv]
 package = true
 

--- a/software/scripts/install-liblsl
+++ b/software/scripts/install-liblsl
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Building and installing liblsl from source..."
+sudo apt install -y cmake g++ git
+
+git clone https://github.com/sccn/liblsl.git /tmp/liblsl
+cd /tmp/liblsl
+mkdir build && cd build
+cmake ..
+cmake --build . --config Release
+sudo cmake --install .
+
+sudo ldconfig
+echo "liblsl installed to /usr/local/lib"

--- a/software/src/main.py
+++ b/software/src/main.py
@@ -76,7 +76,11 @@ def main():
             print("File not found")
             return
 
-        df = pd.read_csv(path)
+        try:
+            df = pd.read_csv(path)
+        except IsADirectoryError:
+            print("Invalid file name")
+            return
 
         result = data_processing.process_pipeline(df)
 


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes the broken resolve streams in main. The broken streams are a result of a pylsl version mismatch. As a result, it is required to use uv to install packages for this project to ensure that versions are locked. This PR adds a script to install the liblsl library, a requirement for pylsl to work. It also adds an IsADirectoryError to main so that no exception is thrown.

## Type of Change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Refactor
-   [ ] Documentation